### PR TITLE
Fix: 細かいエラーの修正と、Update:home画面の文言を変更

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -19,6 +19,7 @@ class AssignsController < ApplicationController
 
   def destroy
     assign = Assign.find(params[:id])
+    assign.destroy #この記載漏れで、削除が出来ていなかった。
     redirect_to teams_path(params[:team_id]), notice: "#{assign.team.name}から外れました"
   end
 

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,7 +1,8 @@
 class HomesController < ApplicationController
   skip_before_action :authenticate_user!
   def index
-    @team = current_user.assign_teams
-    @issue = current_user.issues
+    @teams = Team.all.includes(:user)
+    @issues = Team.all.includes(:user, :team)
+    @plans = Team.all.includes(:user, :team, :issue)
   end
 end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,10 +1,11 @@
 class IssuesController < ApplicationController
   before_action :set_issue, only: %i[show edit update destroy]
   before_action :set_q, only: %i[index search]
-  before_action :set_teams, only: %i[ create edit update]
+  before_action :set_teams, only: %i[create edit update]
 
   # GET /issues or /issues.json
   def index
+    @team = current_user.assign_teams
     @issues = Issue.all
     @issues = @issue_q.result.order(:due_date_at)
     @plans = Plan.all
@@ -29,7 +30,7 @@ class IssuesController < ApplicationController
 
   # GET /issues/1/edit
   def edit
-    @issue.plans.build
+    # @issue.plans.build #この記載があると、空のブランクが出来てしまう。
   end
 
   # POST /issues or /issues.json
@@ -41,6 +42,7 @@ class IssuesController < ApplicationController
     if current_user.save && @issue.save
       redirect_to team_issue_path(@team, @issue), notice: "課題追加しました！"
     else
+      flash[:alert] = '追加出来ませんでした。'
       render :new
     end
   end
@@ -52,6 +54,7 @@ class IssuesController < ApplicationController
     if @issue.update(issue_params)
       redirect_to team_issue_path(params[:issue][:team_id]), notice:"更新しました"
     else
+      flash[:alert] = '更新出来ませんでした。'
       render :edit
     end
   end
@@ -60,9 +63,9 @@ class IssuesController < ApplicationController
   def destroy
     if current_user.id == @issue.user_id
       @issue.destroy
-      redirect_to issues_path(params[:issue][:team_id]), notice:"削除しました"
+      redirect_to team_issues_path(params[:team_id]), notice:"削除しました"
     else
-      redirect_to issues_path(params[:issue][:team_id]), notice: "権限なしのため削除できません。"
+      redirect_to team_issues_path(params[:team_id]), notice: "権限なしのため削除できません。"
     end
   end
 
@@ -74,19 +77,19 @@ class IssuesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def issue_params
-      params.require(:issue).permit(:title, 
-                                    :detail, 
-                                    :image, 
-                                    :image_cache, 
-                                    :cause, 
-                                    :goal, 
-                                    :gap, 
-                                    :due_date_at, 
-                                    :priority, 
-                                    :status, 
+      params.require(:issue).permit(:title,
+                                    :detail,
+                                    :image,
+                                    :image_cache,
+                                    :cause,
+                                    :goal,
+                                    :gap,
+                                    :due_date_at,
+                                    :priority,
+                                    :status,
                                     :done_flag,
-                                    :id, 
-                                    :user_id, 
+                                    :id,
+                                    :user_id,
                                     :team_id,
                                     teams: %i[name owner_id],
                                     plans_attributes: %i[id user_id team_id action pic due_date_at status feedback _destroy])

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -24,7 +24,7 @@ class PlansController < ApplicationController
 
   # GET /plans/1/edit
   def edit
-    @plan = @issue.plans.build
+    # @plan = @issue.plans.build
   end
 
   # POST /plans or /plans.json
@@ -36,7 +36,8 @@ class PlansController < ApplicationController
       if @plan.save
         redirect_to team_issue_plan_path(@team, @issue, plan), notice: "action planを作成しました"
       else
-        render new, notice: "保存できませんでした"
+        flash[:alert] = '保存出来ませんでした。'
+        render new
       end
   end
 
@@ -45,7 +46,8 @@ class PlansController < ApplicationController
     if @plan.update(plan_params)
       redirect_to @plan, notice: "action planを更新しました"
     else
-      render :edit, notice: "更新できませんでした"
+      flash[:alert] = '更新出来ませんでした。'
+      render :edit
     end
   end
 
@@ -74,7 +76,7 @@ class PlansController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def plan_params
-      params.require(:plan).permit(:action, :pic, :due_date_at, :status, :feedback,teams: %i[name owner_id])
+      params.require(:plan).permit(:action, :pic, :due_date_at, :status, :feedback, :_destroy)
     end
 
     def set_teams

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -13,10 +13,10 @@ class TeamsController < ApplicationController
 
   # GET /teams/1 or /teams/1.json
   def show
-    @assing = current_user.assigns.find_by(team_id: @team.id)
-    @assings = @team.members
+    @assign = current_user.assigns.find_by(team_id: @team.id)
+    @members = @team.members
     @issues = @team.issues
-    @plans = @team.plans
+    # @plans = @team.plans
     data = @team.plans.group(:pic).count
     @data = data.transform_keys!{|k| User.find(k).name }
   end
@@ -38,23 +38,30 @@ class TeamsController < ApplicationController
       @team.invite_member(@team.owner)
       redirect_to teams_path(params[:team_id]), notice: "チームを作成しました"
     else
-      render 'new',notice: "作成出来ませんでした"
+      flash[:alert] = '作成出来ませんでした'
+      render :new
     end
   end
 
   # PATCH/PUT /teams/1 or /teams/1.json
   def update
-    if @team.update(team_params)
-      redirect_to teams_path(params[:team_id]), notice: "更新しました"
+    if current_user.id == @team.owner_id
+        @team.update(team_params)
+        redirect_to teams_path(params[:team_id]), notice: "更新しました"
     else
-      render :edit, notice: "更新できませんでした"
+      flash[:alert] = 'チームリーダーのみ編集が可能です。'
+      render :edit
     end
   end
 
   # DELETE /teams/1 or /teams/1.json
   def destroy
-    @team.destroy
-    redirect_to teams_path(params[:team_id]), notice: "チーム削除しました"
+    if current_user.id == @team.owner_id
+      @team.destroy
+      redirect_to teams_path(params[:team_id]), notice: "チーム削除しました"
+    else
+      redirect_to teams_path(params[:team_id]), notice: "チームリーダーのみ削除できます"
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,8 +7,8 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @team = Team.find(@user.assign_teams.ids)
-    # @teams = Team.where(@user.assign_teams)
     @issue = Issue.find(@user.issues.ids)
+    @plan =  Plan.find(@user.plans.ids)
   end
 
   def image

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -67,23 +67,29 @@
         <div class="col-lg-4 text-center">
           <%= image_tag ("3ppl.png"), class: "img-fluid rounded-circle", style: "border-radius: 50%; object-fit:cover;" %>
           <h2 class = "heading text-center">チーム</h2>
-          <p class="text-center">チーム作成者はチームの編集と削除ができます。<br>
-          メールアドレスを使って、招待できます。
-          参加したいチームを見つけて参加もできます。</p>
-          <p class="text-center"><%= link_to('チーム一覧', teams_path, {class: "btn btn-secondary me-2"}) %></p>
+          <p class="text-center">
+          所属したいチームがない場合は作成出来ます。<br>
+          チーム作成者はチームの編集と削除ができます。<br>
+          メールアドレスを使って、招待できます。</p>
+          <p class="text-center"><%= link_to('チーム全体一覧', teams_path, {class: "btn btn-secondary me-2"}) %></p>
         </div><!-- /.col-lg-4 -->
 
         <div class="col-lg-4 text-center">
-        <%= image_tag ("meeting.png"), class: "img-fluid rounded-circle", style: "border-radius: 50%; object-fit:cover;"%>
-          <h2 class = "heading text-center" > 課題</h2>
-          <p class="text-center">問題が起きたらissue作成しましょう</p>
-          <p class="text-center"><%= link_to('解決したい課題一覧', team_issues_path(@team), {class: "btn btn-secondary me-2"}) %></p>
+        <%= image_tag ("meeting.png"), class: "img-fluid rounded-circle", style: "border-radius: 50%; width: 280px; height: 250px; object-fit:cover;"%>
+          <h2 class = "heading text-center" >課題</h2>
+          <p class="text-center">
+          所属チーム一覧から該当チームの詳細画面で課題を作成します。<br>
+          具体的に書くことで、解決策が見えてくるかもしれません。</p>
+          <p class="text-center"><%= link_to('所属チーム一覧', teams_path, {class: "btn btn-secondary me-2"}) %></p>
         </div><!-- /.col-lg-4 -->
 
         <div class="col-lg-4 text-center">
         <%= image_tag ("memo.png"), class: "img-fluid rounded-circle", style: "border-radius: 50%; width: 280px; height: 250px; object-fit:cover;" %>
           <h2 class = "heading text-center">アクション</h2>
-          <p class="text-center">マイページでアクションプランを確認しましょう</p>
+          <p class="text-center">
+          マイページでアクションプランを確認しましょう。<br>
+          期限が近づいているアクションプランを優先的に行いましょう。<br>
+          何か問題があれば遠慮なく、周りに相談しましょう。</p>
           <p class="text-center"><p class="text-center"><%= link_to('Action一覧', user_path(current_user), {class: "btn btn-secondary me-2"}) %></p>
         </div><!-- /.col-lg-4 -->
       </div><!-- /.row -->
@@ -205,10 +211,10 @@
               アクションプランの明確化<br>
             </h3>
             <ul class="list-unstyled mt-3 mb-4">
-              <li>誰が Who?  いつ When?</li>
-              <li>どこで Where?  何を What?</li>
-              <li>なぜ Why?</li>
-              <li>どのように How?</li>
+              <li>Who? 誰が / When? いつ</li>
+              <li>Where? どこで / What? 何を</li>
+              <li>Why? なぜ / How? どのように</li>
+              <li>を明確にする</li>
             </ul>
           </div>
         </div>
@@ -224,9 +230,9 @@
               実際に行動に起こす<br>
             </h3>
             <ul class="list-unstyled mt-3 mb-4">
-              <li>計画に従って着実に業務を遂行</li>
-              <li>試行してみましょう</li>
-              <li>目標に対しての進捗度や結果を記録</li>
+              <li>計画に従って着実に業務を遂行する</li>
+              <li>計画通りに行うだけでなく試行する</li>
+              <li>目標に対しての進捗度や結果を記録する</li>
               <li>計画通りに進まない場合にも、その旨を記録する</li>
             </ul>
           </div>
@@ -246,7 +252,7 @@
               <li>設定した目標やアクションプランが達成できているか</li>
               <li>計画通りに実行できたかどうか</li>
               <li>そのプランに無理がないか</li>
-              <li>できなかったらなぜできなかったか分析</li>
+              <li>できなかったらなぜできなかったか分析する</li>
             </ul>
           </div>
         </div>
@@ -264,9 +270,8 @@
             </h3>
             <ul class="list-unstyled mt-3 mb-4">
               <li>引き続き計画通りに進める</li>
-              <li>計画を続ける中で、いくつかの視点を改善</li>
-              <li>計画を中止</li>
-              <li>延期する</li>
+              <li>計画を続ける中で、いくつかの視点を改善する</li>
+              <li>計画を中止 or 延期する</li>
             </ul>
           </div>
         </div>

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -11,10 +11,7 @@
     </div>
   <% end %>
 
-  <div class="field">
-    <%= form.label :team_name, "チーム名" %>
-    <%= form.collection_select(:team_id, current_user.assign_teams , :id, :name, include_blank: "選択して下さい" )  %>
-  </div>
+  <%= form.hidden_field :team_id, value: @team.id%>
 
   <div class="field">
     <%= form.label :title %>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -40,14 +40,10 @@
           <td><%= issue.due_date_at %></td>
           <td><%= issue.priority %></td>
           <td><%= issue.status %></td>
-          <td><%= link_to 'Show', team_issue_path(issue.id, team_id: issue.team.id) %></td>
-          <td><%= link_to 'Edit', edit_team_issue_path(issue.id, team_id: issue.team.id) %></td>
-          <td><%= link_to 'Destroy', team_issue_path(issue.id, team_id: issue.team.id), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          <td><%= link_to '詳細', team_issue_path(issue.id, team_id: issue.team.id) %></td>
+          <td><%= link_to '編集', edit_team_issue_path(issue.id, team_id: issue.team.id) %></td>
+          <td><%= link_to '削除', team_issue_path(issue.id, team_id: issue.team.id), method: :delete, data: { confirm: '削除して問題ないですか?' } %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
-
-<br>
-
-<%= link_to '課題を新規作成する', new_team_issue_path %>

--- a/app/views/issues/search.html.erb
+++ b/app/views/issues/search.html.erb
@@ -24,9 +24,9 @@
           <td><%= issue.due_date_at %></td>
           <td><%= issue.priority %></td>
           <td><%= issue.status %></td>
-          <td><%= link_to 'Show', issue %></td>
-          <td><%= link_to 'Edit', edit_issue_path(issue) %></td>
-          <td><%= link_to 'Destroy', issue, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          <td><%= link_to '詳細', team_issue_path(issue.id, team_id: issue.team.id) %></td>
+          <td><%= link_to '編集', edit_team_issue_path(issue.id, team_id: issue.team.id) %></td>
+          <td><%= link_to '削除', team_issue_path(issue.id, team_id: issue.team.id), method: :delete, data: { confirm: '削除して問題ないですか?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,4 +1,4 @@
-<h2>課題一覧</h2>
+<h2>課題詳細</h2>
 <div class="row">
   <div class="col">
     <div class="card mb-3" style="max-width: 540px;">

--- a/app/views/plans/_form.html.erb
+++ b/app/views/plans/_form.html.erb
@@ -12,6 +12,11 @@
   <% end %>
 
   <div class="field">
+    <%= form.label :team_name, "チーム名" %>
+    <%= form.collection_select(:team_id, current_user.assign_teams , :id, :name, include_blank: "選択して下さい" )  %>
+  </div>
+
+  <div class="field">
     <%= form.label :action %>
     <%= form.text_area :action, placeholder: "課題に対するアクションを記入しましょう" %>
   </div>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -15,7 +15,7 @@
 
   <div class="field">
     <%= form.label :action %>
-    <%= form.text_area :action %>
+    <%= form.text_area :action, placeholder: "課題に対するアクションを記入しましょう" %>
   </div>
 
   <div class="field">

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -14,7 +14,7 @@
       <tr>
         <td><%= team.name %></td>
         <td><%= link_to '詳細', team_path(team) %></td>
-        <% if current_user.id == @owner_id %>
+        <% if current_user.id == team.owner_id %>
           <td><%= link_to '編集', edit_team_path(team) %></td>
           <td><%= link_to '削除', team, method: :delete, data: { confirm: 'Are you sure?' } %></td>
         <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -26,9 +26,9 @@
         </tr>
       </thead>
       <tbody>
-          <% @assings.each do |assign| %>
+          <% @members.each do |member| %>
             <tr>
-              <td><%= assign.name %></td>
+              <td><%= member.name %></td>
             </tr>
           <% end %>
       </tbody>
@@ -64,9 +64,9 @@
               <td><%= issue.due_date_at %></td>
               <td><%= issue.priority %></td>
               <td><%= issue.status %></td>
-              <td><%= link_to 'Show', team_issue_path(issue.id, team_id: issue.team.id) %></td>
-              <td><%= link_to 'Edit', edit_team_issue_path(issue.id, team_id: issue.team.id) %></td>
-              <td><%= link_to 'Destroy', team_issue_path(issue.id, team_id: issue.team.id), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+              <td><%= link_to '詳細', team_issue_path(issue.id, team_id: issue.team.id) %></td>
+              <td><%= link_to '編集', edit_team_issue_path(issue.id, team_id: issue.team.id) %></td>
+              <td><%= link_to '削除', team_issue_path(issue.id, team_id: issue.team.id), method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>
@@ -88,6 +88,13 @@
     </table>
 
 
-<%= link_to 'チームを編集する', edit_team_path(@team) %> |
+<% if @assign.present? %>
+  <%= link_to 'チームから外れる', team_assign_path(id: @assign.id, team_id: @assign.team_id), method: :delete, class: 'btn btn-danger' %>
+<% else %>
+<% end %>
+
+<% if current_user.id == @team.owner_id %>
+  <%= link_to 'チームを編集する', edit_team_path(@team) %>
+<% end %>
 <%= link_to 'チーム一覧', teams_path %>
 <%= link_to '課題一覧', team_issues_path(@team, @issue) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,6 +39,20 @@
     </table>
 </div>
 
+<div>
+    <strong>自分が担当しているAction一覧</strong>
+    <table class="table">
+    <tbody>
+        <% @user.plans.each do |plan| %>
+        <tr>
+            <td><%= plan.action %></td>
+            <td><%= link_to "詳細", team_issue_plan_path(@team, @issue) %></td>
+        </tr>
+        <% end %>
+    </tbody>
+    </table>
+</div>
+
 <%= link_to "プロフィール編集", edit_user_registration_path %>
 <%= link_to 'すべてのチーム一覧', teams_path %>
 <%= link_to '参加チーム一覧', teams_path(my_team: "true") %>


### PR DESCRIPTION

- ユーザーがアプリケーションを開くと、ログインページの代わりにホームページに飛ぶようにする
 
- ホームページでは、サービスのコンセプトや機能などの概要を説明を記載する
 
- ユーザーがマイページにアクセスしようとすると、エラーページが表示されるので修正
 
- バリデーションエラーが発生した場合、適切なエラーメッセージを表示するように修正
 
- チームを割り当てようとすると、エラーページが表示されるので修正
 
- チームの編集リンクが表示されるので修正